### PR TITLE
Update HealthCheck APIs: Health, Exit

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   receipt-processor:
     container_name: receipt_processor
@@ -11,7 +9,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: any
+        condition: on-failure
       resources:
         limits:
           cpus: '0.50'

--- a/handlers/health/exit.go
+++ b/handlers/health/exit.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/kevin07696/receipt-processor/domain"
+)
+
+func Exit() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		path = strings.Trim(path, "/")
+		segments := strings.Split(path, "/")
+		param := segments[1]
+		
+		code, err := strconv.Atoi(param)
+		if err != nil {
+			slog.Debug("StatusBadRequest: uuid is invalid", slog.String("code", param), slog.Any("error", err))
+			http.Error(w, domain.ErrorToCodes[domain.ErrBadRequest].Message, domain.ErrorToCodes[domain.ErrBadRequest].Code)
+			return
+		}
+		
+		slog.Debug(fmt.Sprintf("exit code %d", code))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+
+		// Flush the response to ensure it is sent to the client
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+
+		go func(exitCode int) {
+			os.Exit(exitCode)
+		}(code)
+	}
+}

--- a/handlers/health/handler.go
+++ b/handlers/health/handler.go
@@ -1,0 +1,17 @@
+package health
+
+import "net/http"
+
+type Handler struct {
+	router *http.ServeMux
+}
+
+func Handle(router *http.ServeMux) *Handler {
+	h := &Handler{
+		router: router,
+	}
+
+	h.initAppRoutes()
+
+	return h
+}

--- a/handlers/health/health.go
+++ b/handlers/health/health.go
@@ -1,4 +1,4 @@
-package receipt
+package health
 
 import "net/http"
 

--- a/handlers/health/routes.go
+++ b/handlers/health/routes.go
@@ -1,0 +1,6 @@
+package health
+
+func (h *Handler) initAppRoutes() {
+	h.router.HandleFunc("GET /health", HealthCheck())
+	h.router.HandleFunc("GET /exit/{code}", Exit())
+}

--- a/handlers/receipt/get.go
+++ b/handlers/receipt/get.go
@@ -14,8 +14,6 @@ import (
 	"github.com/kevin07696/receipt-processor/domain/receipt"
 )
 
-var idKey = "id"
-
 func GetScore(receiptAPI receipt.IReceiptProcessorService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), time.Second)

--- a/handlers/receipt/routes.go
+++ b/handlers/receipt/routes.go
@@ -1,9 +1,6 @@
 package receipt
 
-import "fmt"
-
 func (h *Handler) initAppRoutes() {
-	h.router.HandleFunc("GET /health", HealthCheck())
 	h.router.HandleFunc("POST /receipts/process", ProcessReceipt(h.receiptAPI))
-	h.router.HandleFunc(fmt.Sprintf("GET /receipts/{%s}/points", idKey), GetScore(h.receiptAPI))
+	h.router.HandleFunc("GET /receipts/{id}/points", GetScore(h.receiptAPI))
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kevin07696/receipt-processor/adapters/loggers"
 	dReceipt "github.com/kevin07696/receipt-processor/domain/receipt"
 	"github.com/kevin07696/receipt-processor/handlers"
+	"github.com/kevin07696/receipt-processor/handlers/health"
 	hReceipt "github.com/kevin07696/receipt-processor/handlers/receipt"
 )
 
@@ -57,6 +58,7 @@ func main() {
 	router := http.NewServeMux()
 
 	hReceipt.Handle(router, &receiptAPI)
+	health.Handle(router)
 
 	app := handlers.NewApp(env.Port, router)
 


### PR DESCRIPTION
- Moved HealthCheck out of Receipt Handlers and made its own handler  group
- Added Exit Handler to  test that my Docker Compose restart policy works
- Removed deprecated version tag in Docker Compose file
- Updated Compose's restart policy to `on-failure`